### PR TITLE
fix: when collection does not have property, should still sort

### DIFF
--- a/localbase/api/actions/get.js
+++ b/localbase/api/actions/get.js
@@ -33,11 +33,13 @@ export default function get(options = { keys: false }) {
         logMessage += `, ordered by "${ orderByProperty }"`
         if (!options.keys) {
           collection.sort((a, b) => {
+            if (!a.hasOwnProperty(orderByProperty) || !b.hasOwnProperty(orderByProperty)) return 0
             return a[orderByProperty].toString().localeCompare(b[orderByProperty].toString())
           })
         }
         else {
           collection.sort((a, b) => {
+            if (!a.hasOwnProperty(orderByProperty) || !b.hasOwnProperty(orderByProperty)) return 0
             return a.data[orderByProperty].toString().localeCompare(b.data[orderByProperty].toString())
           })
         }


### PR DESCRIPTION
There's an issue when collection does not have a property when performing orderBy.

For example:
Let's say you store multiple entities... as cats.
1. {name: "socks", born: "2001"}
2. {name: "ginger"}
3. {name: "furball, born: "2020"}

If you use the existing code and try orderBy('born') it will explode💥 because the property "born" for ginger does not exist.

The fix
Essentially it just does a simple check that both compared entities, both have the desired property.

Hope this helps.